### PR TITLE
Use Libera Chat's own web client for connections to Libera Chat

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,13 +48,13 @@ if (isset($_GET['channel'])) {
 	$channel = "$project-$lang-help";
 }
 
-if (isset($_GET['server'])) {
+if (isset($_GET['server']) && $_GET['server'] !== 'irc.libera.chat') {
 	$server = $_GET['server'];
+	$targetURL = 'https://kiwiirc.com/nextclient/' . urlencode($server) . '/' . urlencode($channel) . '?nick=' . urlencode($nick);
 } else {
 	$server = 'irc.libera.chat';
+	$targetURL = 'https://web.libera.chat/?nick=' . urlencode($nick) . '#' . urlencode($channel);
 }
-
-$targetURL = 'https://kiwiirc.com/nextclient/' . urlencode($server) . '/' . urlencode($channel) . '?nick=' . urlencode($nick);
 
 if (isset($_GET['debug'])) {
 	echo('Location: '.htmlspecialchars($targetURL).'<hr>');


### PR DESCRIPTION
kiwiirc.com has been very unstable recently (see kiwiirc/kiwiirc#1884, kiwiirc/kiwiirc#1879, kiwiirc/kiwiirc#1853, etc), so switching to an alternate provider seems prudent. This change keeps using kiwiirc.com for any links to other networks, but uses Libera Chat's self-hosted instance of KikiIRC for connections there.